### PR TITLE
incorrect fgetc return data type

### DIFF
--- a/src/tools/send2flx.c
+++ b/src/tools/send2flx.c
@@ -191,7 +191,7 @@ void read_file(FILE *fp, unsigned char *buffer, eFileType *filetype, int *filesi
 		short sc = 0;
 		int spaces = 0;
 		int i = 0;
-		char c;
+		int c;
 	        while ((c = fgetc(fp)) != EOF && i < MAX_FILESIZE - 3) {
         	        if (c != ' ' && c != '\t' && spaces) {
                 	        if (sc && spaces > 1) {


### PR DESCRIPTION
fgetc returns type int, not char.  The != comparison for EOF will always be true in read_file with 'c' as char.