### PR TITLE
fix unused parameter warnings

### DIFF
--- a/src/testmain.cpp
+++ b/src/testmain.cpp
@@ -2,7 +2,11 @@
 #include "test_gccasm.h"
 
 
+#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
 int main(int argc, char *argv[])
+#else
+int main()
+#endif
 {
     bool failure = false;
 


### PR DESCRIPTION
argv and argc are unused when building on non-x86 platforms. 